### PR TITLE
Changing the package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "doshii-sdk",
+  "name": "doshii-partner-node-sdk",
   "version": "3.0.0",
   "author": "Doshii",
   "description": "Module for Doshii partner APIs",


### PR DESCRIPTION
doshii-sdk already exists and is locked for publishing.
After talking with John we decided the name is too generic anyway so updating to match the github repo name