### PR TITLE
Surcounts pluralisation bug

### DIFF
--- a/lib/transaction.ts
+++ b/lib/transaction.ts
@@ -75,7 +75,7 @@ export interface TransactionResponse {
   method: PaymentMethod;
   tip: number;
   trn: string;
-  surcount: Array<Surcount>;
+  surcounts: Array<Surcount>;
   id: string;
   orderId: string;
   acceptLess: boolean;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doshii-partner-node-sdk",
-  "version": "4.0.3",
+  "version": "4.0.4",
   "author": "Doshii",
   "description": "Module for Doshii partner APIs",
   "main": "dist/index.js",


### PR DESCRIPTION
Fixing a typo in one of the surcounts properties whereby it was missing the pluralisation. Thanks for spotting this @samjcapiznon 