### PR TITLE
SH-1730: bump version to 5.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doshii-partner-node-sdk",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "author": "Doshii",
   "description": "Module for Doshii partner APIs",
   "main": "dist/index.js",


### PR DESCRIPTION
The published version 5.0.1 does not have the dist library files included, bump version for latest release