### PR TITLE
CORE-1155 Add permissions block and update actions to v4

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, dev]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -15,9 +18,9 @@ jobs:
         node-version: [20.x, 22.x, 24.x]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci


### PR DESCRIPTION
## Summary

Resolves the CodeQL warning about missing permissions on the CI workflow.

## Changes

- Add explicit `permissions: { contents: read }` to the workflow, applying the principle of least privilege for the GITHUB_TOKEN
- Update `actions/checkout` from v2 to v4
- Update `actions/setup-node` from v2 to v4

The v2 actions used deprecated Node.js 12 runners.

## Jira

https://doshii.atlassian.net/browse/CORE-1155